### PR TITLE
Added missing codeblocks

### DIFF
--- a/noetic/magnisilver/lidars/ur50.md
+++ b/noetic/magnisilver/lidars/ur50.md
@@ -69,39 +69,48 @@ Additionally to whats shown on the video, make sure:
 LiDAR UR50 network setup on Ubuntu 20.04
 Ubuntu changed the way to set static IPs when they upgraded to 20.04. To assign a static IP using netplan create/edit the following:
 
-/etc/systemd/network/10-eth-dhcp.network:
+**/etc/systemd/network/10-eth-dhcp.network**:
+```toml
+[Match]
+Name=eth0
 
-  [Match]
-  Name=eth0
+[Link]
+RequiredForOnline=no
 
-  [Link]
-  RequiredForOnline=no
+[Network]
+ConfigureWithoutCarrier=true
+Address=192.168.42.125/24
+```
 
-  [Network]
-  ConfigureWithoutCarrier=true
-  Address=192.168.42.125/24
-/etc/netplan/01-netcfg.yaml (create it if not already present):
-
-  network:
-    version: 2
-    renderer: networkd
-    ethernets:
-      eth0:
-       dhcp4: no
-       addresses: [192.168.42.125/24]
-       gateway4: 0.0.0.0
-       nameservers:
-         addresses: [8.8.8.8]
+**/etc/netplan/01-netcfg.yaml** (create it if not already present):
+```yaml
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    eth0:
+     dhcp4: no
+     addresses: [192.168.42.125/24]
+     gateway4: 0.0.0.0
+     nameservers:
+       addresses: [8.8.8.8]
+```
 Since netplan is being used we also need apply the changes:
 
-   sudo netplan --debug apply
-This will flag anyy errors in your file (yaml is space sensitive).
+```bash
+sudo netplan --debug apply
+```
+This will flag any errors in your file (yaml is space sensitive).
 Check to see if things are correct with
-
+```bash
 ifconfig 
-and ping to 192.168.42.222 to see if there is a successful transfer of packets:
+```
 
+and ping to 192.168.42.222 to see if there is a successful transfer of packets:
+```bash
 ping 192.168.42.222
+```
+
 ### Compiling
 
     cd ~/catkin_ws/src


### PR DESCRIPTION
This will fix #72. I hope the base branch `master` is okay. 
The result is:
![image](https://user-images.githubusercontent.com/58706771/214780732-9d3542a9-8f0d-4a6a-87e6-691796ed6abb.png)

## Attention!
I was not able to test it with the "Test Locally" you suggested. 
I got the following errors:
```bash
# Install jekyll
https://jekyllrb.com/docs/installation/
# -- successful -- #

# Install bundler
gem install bundler
# -- successful -- #

cd learn
bundle install
# -- Bundle complete! 1 Gemfile dependency, 91 gems now installed. -- #

bundle exec jekyll serve
Configuration file: /workspaces/learn/_config.yml
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
            Source: /workspaces/learn
       Destination: /workspaces/learn/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
      Remote Theme: Using theme carlosperate/jekyll-theme-rtd
   GitHub Metadata: No GitHub API authentication could be found. Some fields may be missing or have incorrect data.
                    done in 10.937 seconds.
jekyll 3.9.0 | Error:  no implicit conversion of Hash into Integer
/usr/local/rvm/gems/ruby-3.1.3/gems/pathutil-0.16.2/lib/pathutil.rb:502:in `read': no implicit conversion of Hash into Integer (TypeError)
        from /usr/local/rvm/gems/ruby-3.1.3/gems/pathutil-0.16.2/lib/pathutil.rb:502:in `read'
        from /home/codespace/gems/gems/jekyll-3.9.0/lib/jekyll/utils/platforms.rb:75:in `proc_version'
        from /home/codespace/gems/gems/jekyll-3.9.0/lib/jekyll/utils/platforms.rb:40:in `bash_on_windows?'
        from /home/codespace/gems/gems/jekyll-3.9.0/lib/jekyll/commands/build.rb:77:in `watch'
        from /home/codespace/gems/gems/jekyll-3.9.0/lib/jekyll/commands/build.rb:43:in `process'
        from /home/codespace/gems/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:93:in `block in start'
        from /home/codespace/gems/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:93:in `each'
        from /home/codespace/gems/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:93:in `start'
        from /home/codespace/gems/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:75:in `block (2 levels) in init_with_program'
        from /home/codespace/gems/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
        from /home/codespace/gems/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
        from /home/codespace/gems/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
        from /home/codespace/gems/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
        from /home/codespace/gems/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
        from /home/codespace/gems/gems/jekyll-3.9.0/exe/jekyll:15:in `<top (required)>'
        from /home/codespace/gems/bin/jekyll:25:in `load'
        from /home/codespace/gems/bin/jekyll:25:in `<main>'
        from /home/codespace/gems/bin/ruby_executable_hooks:22:in `eval'
        from /home/codespace/gems/bin/ruby_executable_hooks:22:in `<main>'
```

With Docker there is this error:
```bash
Traceback (most recent call last):
        13: from /usr/local/bundle/bin/jekyll:23:in `<main>'
        12: from /usr/local/bundle/bin/jekyll:23:in `load'
        11: from /usr/local/bundle/gems/jekyll-3.8.5/exe/jekyll:11:in `<top (required)>'
        10: from /usr/local/bundle/gems/jekyll-3.8.5/lib/jekyll/plugin_manager.rb:50:in `require_from_bundler'
         9: from /usr/local/lib/ruby/gems/2.5.0/gems/bundler-1.16.3/lib/bundler.rb:101:in `setup'
         8: from /usr/local/lib/ruby/gems/2.5.0/gems/bundler-1.16.3/lib/bundler.rb:135:in `definition'
         7: from /usr/local/lib/ruby/gems/2.5.0/gems/bundler-1.16.3/lib/bundler/definition.rb:35:in `build'
         6: from /usr/local/lib/ruby/gems/2.5.0/gems/bundler-1.16.3/lib/bundler/dsl.rb:13:in `evaluate'
         5: from /usr/local/lib/ruby/gems/2.5.0/gems/bundler-1.16.3/lib/bundler/dsl.rb:218:in `to_definition'
         4: from /usr/local/lib/ruby/gems/2.5.0/gems/bundler-1.16.3/lib/bundler/dsl.rb:218:in `new'
         3: from /usr/local/lib/ruby/gems/2.5.0/gems/bundler-1.16.3/lib/bundler/definition.rb:84:in `initialize'
         2: from /usr/local/lib/ruby/gems/2.5.0/gems/bundler-1.16.3/lib/bundler/definition.rb:84:in `new'
         1: from /usr/local/lib/ruby/gems/2.5.0/gems/bundler-1.16.3/lib/bundler/lockfile_parser.rb:95:in `initialize'
/usr/local/lib/ruby/gems/2.5.0/gems/bundler-1.16.3/lib/bundler/lockfile_parser.rb:108:in `warn_for_outdated_bundler_version': You must use Bundler 2 or greater with this lockfile. (Bundler::LockfileError)
```